### PR TITLE
Add email, background jobs, account settings and system visibility to start-an-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npx skills add leonvanzyl/skills --skill <skill-name>
 
 | Skill | Description |
 | ----- | ----------- |
-| [start-an-app](skills/start-an-app) | Interview-driven app scaffolder: asks what you're building in plain language, recommends the right options (SQLite vs Postgres in Docker, sign-in, file uploads, payments, AI features), and builds a working Next.js app that's yours from the first commit — not a template. |
+| [start-an-app](skills/start-an-app) | Interview-driven app scaffolder: asks what you're building in plain language, recommends the right options (SQLite vs Postgres in Docker, sign-in, transactional email, file uploads, payments, AI features, background jobs), and builds a working Next.js app that's yours from the first commit — not a template. Every app ships with account settings and a system page for logs and debugging. |
 
 ## Adding a new skill
 

--- a/skills/start-an-app/SKILL.md
+++ b/skills/start-an-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-an-app
-description: Interview the user in depth about what they actually want to build, then scaffold a working full-stack web app around it. Use when the user wants to start a new app, website, prototype, or SaaS; when they don't know what tech stack to pick; or when they want a solid working starting point fast. Covers requirements discovery, project setup, database (SQLite or Postgres in Docker), sign-in, file uploads, payments, AI features, and a real landing page and dashboard.
+description: Interview the user in depth about what they actually want to build, then scaffold a working full-stack web app around it. Use when the user wants to start a new app, website, prototype, or SaaS; when they don't know what tech stack to pick; or when they want a solid working starting point fast. Covers requirements discovery, project setup, database (SQLite or Postgres in Docker), sign-in, transactional email, file uploads, payments, AI features, background jobs, a real landing page and dashboard, and an account settings area with system logs and debugging built in.
 ---
 
 # Start an App
@@ -19,9 +19,11 @@ Turn an idea into a running web app. Understand the idea properly first, then bu
 - **Never `drizzle-kit push`.** Schema changes always go through `db:generate` then `db:migrate`, every time, from the very first table.
 - **Ids are randomly generated UUIDs — except in Better Auth's tables.** Every table you define gets one. The tables Better Auth's CLI generates stay exactly as generated, which also means any column pointing at a user stays `text`, not `uuid`. `references/database.md` has both branches.
 - The app is scaffolded **in the current working directory** — that folder is the project root. Never create a subfolder for it and never `cd` into one; the user already chose where the app goes by being there.
-- The stack is fixed: Next.js, TypeScript, Tailwind, shadcn/ui, Drizzle, Better Auth. The interview chooses *within* it (which database, what kind of sign-in, uploads, payments, AI) — it never swaps out these pieces.
+- The stack is fixed: Next.js, TypeScript, Tailwind, shadcn/ui, Drizzle, Better Auth. The interview chooses *within* it (which database, what kind of sign-in, email, uploads, payments, AI, background jobs) — it never swaps out these pieces.
 - **Better Auth owns anything that belongs to a user.** Where Better Auth has a plugin for an integration — payments above all — use the plugin, never the provider's standalone SDK wired in beside it. One source of truth for the user, one place customer ids and webhooks live.
 - Prefer choices that survive deployment. Where a feature works differently in production (uploads, Postgres), the local setup and the deployed setup must be the same code switched by an environment variable — never a second code path the user has to remember to change.
+- **Every app gets a settings area.** Not as a finishing touch — from the first commit, scaled to what the app has. Accounts mean a profile, verification status, password, devices, and a way to leave. Every app, accounts or not, gets a system view: what's configured, what happened, what's running. `references/settings.md` and `references/ops.md`.
+- **Anything the app does out of sight is visible and controllable from inside it.** If the app sends an email, runs work in the background, or acts on a schedule, the user can see it happened, read why it failed, stop it, and try it again — in the app, not by reading logs on a hosting dashboard. Building something the user cannot watch is not finished.
 - All commands, package names, and config live in the reference files, never in this file. Load only the references for the branches the user chose.
 - If a reference command fails because a tool changed (renamed flag, different init flow), check that tool's official docs, use the current equivalent, finish the job, and tell the user at the end that this skill's reference file needs a refresh.
 
@@ -51,11 +53,12 @@ The user has told you the happy path. Your job is the rest. Run through these si
 - **Is anyone special?** An admin, a moderator, an owner who sees more than everyone else.
 - **What does day one look like?** The app opens with zero data. What should be on that screen?
 - **Anything time-based?** Due dates, reminders, recurring items, "this week" views.
-- **Does anyone need telling?** Email on signup, on invite, when something happens.
+- **Does anyone need telling?** Email on signup, on invite, when something happens. If yes, that's the email question in Step 1c — carry the answer forward rather than asking twice.
+- **Does anything take a while?** Work that shouldn't happen while someone waits — importing a file, generating a report, calling a slow service, anything on a schedule. Most apps have none; the ones that do usually mention it here rather than in the happy path.
 - **Phone or desktop?** Changes layout decisions early and is cheap to ask.
 - **What is deliberately *not* in version one?** Ask directly. Naming what's out is what keeps a first version shippable, and it gives you permission to leave things out instead of guessing.
 
-Two or three of these usually matter. Raising all eight is an interrogation — pick the ones that would change what you build.
+Two or three of these usually matter. Raising all nine is an interrogation — pick the ones that would change what you build.
 
 ## Step 1c — Technical choices
 
@@ -71,20 +74,30 @@ Now the branches. One at a time, each with a recommendation. **Don't ask what th
    → Yes: recommend **email + password** as the default ("works immediately, nothing to configure").
    → If they want "Sign in with Google": say yes, and set expectations — it needs a free Google Cloud setup with a few copy-paste steps; offer to walk through it together or add it later.
 
-3. **"Will people upload anything — photos, documents, a profile picture?"**
+3. **"Does the app need to send any email — confirming an address, resetting a password, telling someone something happened?"**
+   → No: skip email entirely. Sign-in still works; there's just no verification or password reset until it's added.
+   → Yes: recommend **Resend**. Set expectations honestly and early, because this is the one component that needs something they may not have: "It works straight away for sending to yourself. To email anyone else you'll need a domain name, and a few DNS records — about ten minutes, and free." If they don't have a domain, take it anyway and say the sending step waits for one — everything else works in the meantime, with emails printed to the terminal.
+   → If they said no to sign-in but yes to email, that's fine — a contact form or a notification doesn't need accounts.
+
+4. **"Will people upload anything — photos, documents, a profile picture?"**
    → No: skip file storage entirely.
    → Yes: no decision to make, so don't offer one. Say what happens: "While you're building, uploads save into a folder in the project. When you deploy, they'll go to proper cloud storage automatically — same code, you just connect a store." Only mention Vercel Blob by name if they ask.
 
-4. **"Will people pay for anything — a subscription, or a one-off purchase?"**
+5. **"Will people pay for anything — a subscription, or a one-off purchase?"**
    → No: skip payments entirely.
    → Yes: recommend **Polar** ("they handle sales tax and VAT worldwide for you, which is the part that usually bites"), with **Stripe** as the option if they already use it or need it.
    → Payments need accounts. If they said no to sign-in, say so plainly and add it: "we'll need accounts too, so the app knows whose subscription is whose."
    → Set expectations: everything is set up in test mode, no real money, and going live is a key swap later.
 
-5. **"Should the app have any AI features — like a chat, or generating text or content?"**
+6. **"Should the app have any AI features — like a chat, or generating text or content?"**
    → Only include AI plumbing if yes. If yes, mention they'll need an OpenRouter API key (free to create) and you'll show them where to get it — one key, many models.
 
-6. **"When someone lands on the app signed out, what should they see?"**
+7. **"Does anything need to keep running on its own — work that carries on after they close the tab, or happens on a schedule?"**
+   → Default is **no**, and most apps should stay there. A server action handles saving a record, sending one email, or resizing one image perfectly well; adding a job system for that is overhead with a dashboard attached.
+   → Yes when work must survive a restart, retry itself after a failure, run on a schedule, fan out over many items, or wait minutes to days for something. Importing a spreadsheet, generating a report, calling a slow external service, a nightly digest.
+   → If yes: recommend **Inngest** ("it runs the work outside the app, picks up where it left off if something crashes, retries on its own, and you can watch every step of it happen while you build"). It's free to start and needs no account at all during development.
+
+8. **"When someone lands on the app signed out, what should they see?"**
    → Decides the front door: a real landing page for something other people will sign up for, or straight into the app for a personal tool. Don't assume a marketing page — `references/pages.md` has the call.
 
 ## Step 2 — Build sheet
@@ -97,11 +110,12 @@ Restate the plan in plain words before touching anything. Example shape:
 > **What you can do:** log a hike, edit it later, delete one, see them newest-first.
 > **Signing in:** email and password, so it's yours alone.
 > **Photos:** saved in the project while you build; they move to cloud storage when you deploy.
+> **Also included:** a settings page where you can change your password and delete your account, and a system page showing what's set up and what's happened.
 > **Not in version one:** sharing hikes with friends, maps, and the stats page — easy to add once the basics feel right.
 >
 > Sound right?
 
-Include the data model and the explicit **not in version one** list — those two lines are what stop a rewrite later. Also mention anything that needs something from them before it can work (Docker running, an API key, a provider account), so there are no surprises mid-build.
+Include the data model and the explicit **not in version one** list — those two lines are what stop a rewrite later. Also mention anything that needs something from them before it can work (Docker running, an API key, a domain for email, a provider account), so there are no surprises mid-build.
 
 Get a clear go-ahead. Adjust anything they push back on. If the answer reopens what the app *is* rather than tweaking a detail, go back to Step 1a — that's cheaper now than after the schema exists.
 
@@ -112,12 +126,18 @@ Work through these in order. Each reference has a **Verify** section — complet
 1. Base project → `references/stack.md`
 2. Database (SQLite or Postgres-in-Docker branch) → `references/database.md`
 3. Sign-in, if chosen (email+password, optionally Google) → `references/auth.md`
-4. File uploads, if chosen → `references/storage.md`
-5. Payments, if chosen → `references/payments.md` (requires step 3)
-6. AI features, if chosen → `references/ai.md`
-7. Landing page and dashboard → `references/pages.md`
+4. Email, if chosen → `references/email.md` (also wires verification and password reset, if step 3 ran)
+5. File uploads, if chosen → `references/storage.md`
+6. Payments, if chosen → `references/payments.md` (requires step 3)
+7. AI features, if chosen → `references/ai.md`
+8. Background jobs, if chosen → `references/jobs.md`
+9. Landing page and dashboard → `references/pages.md`
+10. Account settings → `references/settings.md` (requires step 3; skip only if there is no sign-in)
+11. System visibility → `references/ops.md` (always)
 
-The order matters: payments and uploads both extend what step 3 built, and step 7 needs all of it in place. Anything that changes `src/lib/auth.ts` means regenerating the Better Auth schema and running `db:generate` + `db:migrate` again — the reference files say where.
+The order matters: payments and uploads both extend what step 3 built, step 9 needs all of it in place, and steps 10 and 11 hang off the navigation step 9 creates. Anything that changes `src/lib/auth.ts` means regenerating the Better Auth schema and running `db:generate` + `db:migrate` again — the reference files say where.
+
+Steps 10 and 11 are not a polish pass to drop if time is short. They are what turns a scaffold into something the user can operate.
 
 ## Step 4 — Make it theirs
 
@@ -126,7 +146,8 @@ This is not a polish pass; it is most of the value. The scaffold in Step 3 is in
 - Name the project after their idea (package name, page titles, visible branding).
 - The schema tables are the **nouns** from Step 1a, each with a UUID primary key, and the ownership rule from Step 1b applied — a `userId` column (`text`, matching Better Auth) and every query scoped to it if data is private.
 - Build the real pages: the front door and dashboard from `references/pages.md`, real navigation, and the **verbs** from Step 1a wired up — including editing and deleting if the gap-check said so.
-- Seed nothing generic: every visible string should make sense for *their* app. No "Item", no "Welcome to Next.js", no lorem ipsum.
+- Seed nothing generic: every visible string should make sense for *their* app. No "Item", no "Welcome to Next.js", no lorem ipsum. This includes the settings area and the emails — a section called "Notifications" listing categories the app never sends, or an email signed "My App", is the same failure as a page of lorem ipsum.
+- Build only the settings sections this app has. An empty Billing tab or a Notifications tab for an app that sends no email is worse than a missing one.
 - Done when: someone opening the app would know what it is without being told, and the user can do the main thing the app exists for, end to end.
 
 ## Step 5 — Verify and hand off
@@ -135,8 +156,14 @@ This is not a polish pass; it is most of the value. The scaffold in Step 3 is in
 - `drizzle/` contains generated migration files, `pnpm db:migrate` has been run, and creating one real record works end to end. No schema was ever pushed.
 - The `build` script runs `db:migrate` before `next build`, so a deploy applies pending migrations instead of shipping new code onto an old schema.
 - If sign-in was chosen: signing up, signing out, and signing back in works; `/dashboard` redirects when signed out and shows their own data when signed in.
+- If email was chosen: with no API key set, sending prints the message to the terminal and records it; with a key set, a test send reaches `delivered@resend.dev` and the log shows it. With sign-in too, signing up sends a confirmation and "forgot password" actually resets a password.
 - If uploads were chosen: uploading a file through the app's own UI saves it and it renders after a refresh.
 - If payments were chosen: the test-mode checkout completes and the paid state is visible server-side.
+- If AI was chosen: the feature works against a real key, and it is the feature the interview asked for rather than a bare chat box.
+- If background jobs were chosen: the dev server at http://localhost:8288 shows the run and its steps, a deliberate failure retries and is visible, and the job's row ends in the right state.
+- Where there is sign-in: `/settings` is reachable from the app's navigation, the profile saves, the password changes, another device can be signed out, and deleting a test account really removes it and its data.
+- The system page exists, shows what is and isn't configured without printing a single key or token, and is refused server-side to a second, non-admin account.
 - **Missing keys degrade, never crash.** With `.env` values absent, the app still starts and the affected feature shows a friendly "not configured yet" notice.
 - Close with a plain-language summary: how to start the app (including `pnpm db:up` if Postgres is in Docker), what each entry in `.env` is for, and two or three sensible next steps.
-- Where local and production differ, spell out the one-time switch: connect a Blob store for uploads, point `POSTGRES_URL` at a hosted database, swap payment keys out of test mode. Each is a setting on the host, not a code change — say that, because it's the part people expect to be hard.
+- Show them the system page and say what it's for. It is the answer to "why didn't that email arrive?" and "is that still running?", and they will not find it on their own.
+- Where local and production differ, spell out the one-time switch: connect a Blob store for uploads, point `POSTGRES_URL` at a hosted database, swap payment keys out of test mode, add the Resend key once the domain is verified, add the Inngest keys and sync the app. Each is a setting on the host, not a code change — say that, because it's the part people expect to be hard. The two that also need an action outside the host are verifying the email domain in DNS and syncing the app with Inngest after the first deploy; call those out by name.

--- a/skills/start-an-app/references/auth.md
+++ b/skills/start-an-app/references/auth.md
@@ -68,6 +68,10 @@ export const { signIn, signUp, signOut, useSession } = authClient;
 
 Build simple `/sign-in` and `/sign-up` pages with shadcn form components using `signIn.email` / `signUp.email`, and show the signed-in user (with a sign-out button) in the app's header via `useSession`.
 
+**No email verification or password reset yet, and that's deliberate.** Better Auth can do both, but neither exists until there is somewhere to send the message from. If the user chose email, `references/email.md` wires them up; if they didn't, sign-in works exactly as configured above and reset can be added later without touching anything here.
+
+`references/settings.md` later adds a `role` field and a couple of session options to this file, and regenerates the schema. Nothing above needs to change for that.
+
 ## Google sign-in (optional add-on)
 
 Walk the user through it — plain language, one step at a time:

--- a/skills/start-an-app/references/email.md
+++ b/skills/start-an-app/references/email.md
@@ -1,0 +1,317 @@
+# Transactional email (Resend)
+
+Last verified: 2026-08-09
+
+**Purpose:** Send the emails the app owes people — verify your address, reset your password, here's your receipt, someone invited you. Real delivery in production, and a readable log locally without sending anything to anyone.
+
+> **Hard rule: nothing sends until it's logged.** Every message goes through `src/lib/email.ts`, which writes an `email_log` row first and sends second. That row is what `references/ops.md` renders, what tells the user *why* an email never arrived, and what survives Resend's 30-day retention. Never call `resend.emails.send()` directly from a page, action, or route.
+>
+> If Resend's documentation and this file disagree on *how to integrate*, this file wins. If they disagree on a DNS record, dashboard path, or API detail, Resend's docs win — update this file afterwards.
+
+**Sign-in is not required.** A contact form or a notification-only app can send email with no accounts at all. But if `references/auth.md` ran, this file also wires up email verification and password reset — Better Auth cannot do either without a sender, so those features simply do not exist until this step runs.
+
+## Install
+
+```bash
+pnpm add resend react-email
+pnpm add -D @react-email/ui
+```
+
+> React Email 6 merged everything into the single `react-email` package. Import components, `render`, and `toPlainText` from `"react-email"` — **not** `@react-email/components`, and not the per-component `@react-email/button` packages. Those still install and still resolve, which is exactly why the mistake is easy to make and hard to spot. `@react-email/ui` is the local preview server only, hence `-D`.
+
+Append to `.env`:
+
+```
+RESEND_API_KEY=
+EMAIL_FROM="My App <hello@send.example.com>"
+```
+
+Leave `RESEND_API_KEY` **empty for now**. An empty key is the local development mode — see *How sending is switched* below — so the app is fully working before the user has an account or a domain.
+
+Add the preview server to `package.json`:
+
+```json
+"email:dev": "email dev --dir src/emails"
+```
+
+## Set up the Resend account
+
+Do this when the user is ready to send to somebody other than themselves. Say that plainly first, because it decides whether they need a domain today:
+
+> Resend gives you a test address, `onboarding@resend.dev`, that works instantly — but it will **only** deliver to the email address you signed up with. The moment you want to email anyone else, you need to prove you own a domain. That's a DNS change, about ten minutes, and it's free.
+
+Then walk them through it, one step at a time:
+
+1. Open https://resend.com and sign up.
+2. **Domains → Add Domain.** Enter a **subdomain**, not the bare domain — `send.theirdomain.com` or `notifications.theirdomain.com`. Explain why in one line: if something ever goes wrong with deliverability, it damages the subdomain's reputation and leaves their main domain, and their normal email, untouched. Pick the region closest to them.
+3. Resend shows three DNS records. Add all three at their domain registrar, exactly as shown:
+   - an **MX** record on `send` (priority 10) — this is how bounces come back
+   - a **TXT** record on `send` — SPF, which says Resend is allowed to send as them
+   - a **TXT** record on `resend._domainkey` — DKIM, which signs each message
+   Paste the names exactly as Resend gives them (`send`, not `send.theirdomain.com`) — most registrars add the domain themselves. On Cloudflare, set these to **DNS only**, with the orange proxy cloud off.
+4. Click **Verify**. It usually completes in under fifteen minutes. If it stalls, the records are almost always right but not yet visible — wait and press it again rather than editing them.
+5. Once verified, add one more **TXT** record on `_dmarc` with the value `v=DMARC1; p=none;`. It isn't needed for verification, but Gmail and Outlook increasingly expect it.
+6. **API Keys → Create API Key.** Set permission to **Sending access** and restrict it to the domain just added. Copy it — it is shown once.
+
+Fill in `.env`:
+
+```
+RESEND_API_KEY=re_<from step 6>
+EMAIL_FROM="<App name> <hello@send.theirdomain.com>"
+```
+
+Any address at the verified domain works — there is no separate "sender" to create.
+
+**Free tier, so there are no surprises:** 100 emails a day, 3,000 a month, one domain. That is generous for a new app and worth saying out loud.
+
+## Configure
+
+### The send helper
+
+`src/lib/email.ts` is the only file that talks to Resend. It switches on **whether the key is present**, not on a mode flag or `NODE_ENV` — same rule as `references/storage.md`, so nothing has to be remembered at deploy time.
+
+```ts
+import "server-only";
+import { Resend } from "resend";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { emailLog } from "@/lib/db/schema";
+
+const apiKey = process.env.RESEND_API_KEY;
+export const emailConfigured = Boolean(apiKey);
+
+const resend = apiKey ? new Resend(apiKey) : null;
+const from = process.env.EMAIL_FROM ?? "My App <onboarding@resend.dev>";
+
+type SendArgs = {
+  to: string;
+  subject: string;
+  react: React.ReactNode;
+  template: string;
+};
+
+export async function sendEmail({ to, subject, react, template }: SendArgs) {
+  const [row] = await db
+    .insert(emailLog)
+    .values({ to, subject, template, status: "pending" })
+    .returning();
+
+  if (!resend) {
+    console.info(
+      `\n[email] ${subject}\n[email] to: ${to}\n[email] not sent — RESEND_API_KEY is empty. Logged as ${row.id}.\n`,
+    );
+    await db
+      .update(emailLog)
+      .set({ status: "logged" })
+      .where(eq(emailLog.id, row.id));
+    return { id: row.id };
+  }
+
+  const { data, error } = await resend.emails.send(
+    { from, to, subject, react },
+    { idempotencyKey: `${template}/${row.id}` },
+  );
+
+  await db
+    .update(emailLog)
+    .set(
+      error
+        ? { status: "failed", error: error.message }
+        : { status: "sent", providerId: data!.id },
+    )
+    .where(eq(emailLog.id, row.id));
+
+  return { id: row.id };
+}
+```
+
+Three things in there are not optional, and all three are easy to get wrong:
+
+- **`resend.emails.send()` does not throw on an API error.** It returns `{ data, error }`. A `try`/`catch` around it catches network failures only and silently swallows every rejected send — wrong domain, unverified sender, over quota. Check `error`.
+- **`idempotencyKey` is the second argument**, not a field in the payload. Put it in the payload and it is ignored, and a retried request sends twice.
+- **Parameters are camelCase in the Node SDK** — `replyTo`, `scheduledAt`. The REST API uses snake_case; the SDK does not, and it fails silently rather than erroring.
+
+Anything that sends must run on the Node runtime. In a route handler, say so explicitly:
+
+```ts
+export const runtime = "nodejs";
+```
+
+### The log table
+
+Add to `src/lib/db/schema.ts` — Postgres branch shown; on SQLite use a `text` id with `$defaultFn(() => crypto.randomUUID())` and `integer` timestamps, exactly as `references/database.md` describes.
+
+```ts
+export const emailLog = pgTable("email_log", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  to: text("to").notNull(),
+  subject: text("subject").notNull(),
+  template: text("template").notNull(),
+  status: text("status").notNull(), // pending | logged | sent | delivered | bounced | complained | failed
+  providerId: text("provider_id"),
+  error: text("error"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+```
+
+```bash
+pnpm db:generate
+pnpm db:migrate
+```
+
+### Templates
+
+Templates live in `src/emails/`. One file per message, plain and short — an email is not a landing page.
+
+```tsx
+// src/emails/verify-email.tsx
+import { Body, Button, Container, Head, Html, Preview, Text } from "react-email";
+
+export default function VerifyEmail({ url, name }: { url: string; name?: string }) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Confirm your email address</Preview>
+      <Body style={{ fontFamily: "sans-serif", backgroundColor: "#fff" }}>
+        <Container style={{ maxWidth: 480, padding: "32px 0" }}>
+          <Text>Hi{name ? ` ${name}` : ""},</Text>
+          <Text>Confirm your email address to finish setting up your account.</Text>
+          <Button href={url} style={{ background: "#000", color: "#fff", padding: "12px 20px", borderRadius: 6 }}>
+            Confirm email
+          </Button>
+          <Text style={{ color: "#666", fontSize: 13 }}>
+            If you didn&apos;t create an account, you can ignore this email.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+```
+
+`pnpm email:dev` opens a preview at http://localhost:3000 with a mobile toggle, the plain-text version, and a spam check. It's the fastest way to iterate, and it sends nothing.
+
+Write the copy for *their* app, in their voice. "Confirm your email to start logging hikes" beats "Verify your account".
+
+### Wiring Better Auth (only if sign-in was chosen)
+
+Extend `src/lib/auth.ts`. This adds to the existing config; it replaces nothing:
+
+```ts
+import { sendEmail } from "@/lib/email";
+import VerifyEmail from "@/emails/verify-email";
+import ResetPassword from "@/emails/reset-password";
+
+export const auth = betterAuth({
+  // ...existing config
+  emailAndPassword: {
+    enabled: true,
+    sendResetPassword: ({ user, url }) => {
+      void sendEmail({
+        to: user.email,
+        subject: "Reset your password",
+        react: ResetPassword({ url, name: user.name }),
+        template: "reset-password",
+      });
+    },
+  },
+  emailVerification: {
+    sendOnSignUp: true,
+    autoSignInAfterVerification: true,
+    sendVerificationEmail: ({ user, url }) => {
+      void sendEmail({
+        to: user.email,
+        subject: "Confirm your email address",
+        react: VerifyEmail({ url, name: user.name }),
+        template: "verify-email",
+      });
+    },
+  },
+});
+```
+
+> **`void`, not `await`.** This is Better Auth's own instruction and it is a security rule, not a style preference: awaiting the send makes the response measurably slower when the account exists than when it doesn't, which tells an attacker who has an account. Fire it and return.
+
+**Leave `requireEmailVerification` off.** Blocking sign-in on verification turns one mistyped address into a support request the user cannot answer. `references/settings.md` builds the banner-and-resend pattern instead, which nags without locking anyone out.
+
+Adding these hooks does not change the schema, so there is no Better Auth CLI regeneration here.
+
+### Delivery status (optional, worth it)
+
+Resend can tell the app what happened after the send. Add `src/app/api/webhooks/resend/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { db } from "@/lib/db";
+import { emailLog } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export const runtime = "nodejs";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text(); // raw body — parsing it breaks the signature
+
+  let event;
+  try {
+    event = resend.webhooks.verify({
+      payload,
+      headers: {
+        id: req.headers.get("svix-id")!,
+        timestamp: req.headers.get("svix-timestamp")!,
+        signature: req.headers.get("svix-signature")!,
+      },
+      webhookSecret: process.env.RESEND_WEBHOOK_SECRET!,
+    });
+  } catch {
+    return new NextResponse("Invalid signature", { status: 400 });
+  }
+
+  const status = event.type.replace("email.", "");
+  await db
+    .update(emailLog)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(emailLog.providerId, event.data.email_id));
+
+  return new NextResponse(null, { status: 200 });
+}
+```
+
+Register it under **Webhooks → Add Endpoint** at `https://<their-domain>/api/webhooks/resend`, and put the signing secret in `.env` as `RESEND_WEBHOOK_SECRET`. Signature verification needs the **raw** body — reading it as JSON and re-serialising changes the bytes and every request fails.
+
+Resend keeps 30 days of history. `email_log` is the app's own record and keeps whatever the user wants, which is the point of writing it first.
+
+## Testing locally
+
+With `RESEND_API_KEY` empty, nothing leaves the machine: the message is logged to the terminal with the link clickable, and a row lands in `email_log`. That is the normal way to develop, and it means signup and password reset work end to end on day one.
+
+To test real delivery, set the key and send to Resend's simulation addresses — these are real, documented, and safe:
+
+| Address | What it simulates |
+| --- | --- |
+| `delivered@resend.dev` | a successful delivery |
+| `bounced@resend.dev` | a hard bounce |
+| `complained@resend.dev` | the recipient marking it as spam |
+| `suppressed@resend.dev` | a previously-bounced address |
+
+The first three accept a label, so `delivered+alice@resend.dev` and `delivered+bob@resend.dev` are distinct test users. `suppressed@` does not.
+
+Do **not** test with `@example.com` or `@test.com` — Resend rejects them with a 422 rather than letting them damage the account's bounce rate.
+
+## Going to production
+
+Nothing in the code changes. Set `RESEND_API_KEY` and `EMAIL_FROM` in the host's environment variables and the same code sends for real. Tell the user that at hand-off, along with the two limits that actually bite: 100 emails a day on the free plan, and 10 API requests per second.
+
+If they ever add marketing email — a newsletter, product updates — send it from a **different** subdomain than this one. Campaign complaints must never be able to affect whether password resets arrive.
+
+## Verify
+
+- `pnpm email:dev` opens the preview and each template renders, on desktop and mobile widths.
+- With `RESEND_API_KEY` empty: triggering an email prints it to the terminal, the link in it works when pasted into the browser, and a row appears in `email_log` with status `logged`.
+- With a real key: sending to `delivered@resend.dev` returns success and the row reaches status `sent`, visible in `pnpm db:studio` or in the app's own email log.
+- Sign-in branch only: signing up sends a verification email and clicking the link marks the account verified; "forgot password" sends a reset link that actually resets the password.
+- Every email's wording is about *their* app — no "My App", no placeholder addresses.
+- With `.env` values absent, the app still starts and email degrades to the log instead of crashing.

--- a/skills/start-an-app/references/jobs.md
+++ b/skills/start-an-app/references/jobs.md
@@ -1,0 +1,253 @@
+# Background processing (Inngest)
+
+Last verified: 2026-08-09
+
+**Purpose:** Run work that shouldn't happen inside a web request — anything slow, anything that has to retry itself, anything on a schedule, anything that must survive the server restarting mid-way. And make all of it visible from inside the app.
+
+> **Hard rule: the app keeps its own record of every job.** A row goes into the `jobs` table *before* the event is sent, and the function updates it as it goes. Inngest is the engine and the live detail view; the `jobs` table is the record. This is not belt-and-braces — Inngest's free plan keeps 24 hours of history, and its API is account-wide rather than scoped to one of the app's users, so it can be neither the archive nor the thing a user is allowed to query. `references/ops.md` renders this table.
+>
+> If Inngest's documentation and this file disagree on *how to structure this*, this file wins. If they disagree on an API shape or dashboard path, their docs win — update this file afterwards.
+
+**Only open this file if the interview genuinely called for it.** Sending one email, resizing one image, or writing one row does not need a job queue; a server action does that fine. This earns its place when work must survive a restart, retry on failure, run on a schedule, fan out over many items, or wait for something that takes minutes to days. If none of that came up, close this file — an unused job system is pure overhead.
+
+> Inngest's SDK v4 changed enough that older examples are actively wrong: triggers moved *inside* the config object, `EventSchemas` was replaced, and the SDK now assumes production unless told otherwise. Almost every tutorial and blog post online is still v3. Use what's below; if something doesn't compile, check Inngest's current docs rather than a search result.
+
+## Install
+
+```bash
+pnpm add inngest
+pnpm add -D inngest-cli concurrently
+```
+
+Append to `.env`:
+
+```
+INNGEST_DEV=1
+```
+
+That one line is the whole local setup. `INNGEST_DEV=1` tells the SDK to talk to the local dev server and skip signature checks — without it, v4 assumes production and demands a signing key. Production keys come later, at deploy time.
+
+Change the `dev` script in `package.json` so both processes start together:
+
+```json
+"dev": "concurrently -n next,inngest -c cyan,magenta \"next dev\" \"inngest-cli dev -u http://localhost:3000/api/inngest\"",
+```
+
+`concurrently` rather than `&` or `&&`: those behave differently across shells and don't work on Windows at all.
+
+## Configure
+
+### The client
+
+`src/lib/inngest/client.ts`:
+
+```ts
+import { Inngest } from "inngest";
+
+export const inngest = new Inngest({
+  id: "my-app", // kebab-case app name; this id is what production syncs against
+  checkpointing: { maxRuntime: "200s" },
+});
+```
+
+`maxRuntime` must sit comfortably below the hosting platform's function timeout. On Vercel that's 300 seconds, so 200 is a safe margin — the SDK wraps up and hands back before the platform kills the request.
+
+### The endpoint
+
+`src/app/api/inngest/route.ts`:
+
+```ts
+import { serve } from "inngest/next";
+import { inngest } from "@/lib/inngest/client";
+import { functions } from "@/lib/inngest/functions";
+
+export const maxDuration = 300;
+
+export const { GET, POST, PUT } = serve({ client: inngest, functions });
+```
+
+All three verbs are required: `PUT` registers the app, `POST` runs functions, `GET` is introspection. Miss one and the dev server finds the app but can't do anything with it.
+
+### A function
+
+`src/lib/inngest/functions.ts`. Name the function after the real work from the interview — `generate-monthly-report`, `import-csv`, `send-digest` — not `process-task`.
+
+```ts
+import { NonRetriableError } from "inngest";
+import { eq } from "drizzle-orm";
+import { inngest } from "./client";
+import { db } from "@/lib/db";
+import { jobs } from "@/lib/db/schema";
+
+export const generateReport = inngest.createFunction(
+  {
+    id: "generate-report",
+    triggers: { event: "app/report.requested" },
+    retries: 4,
+    onFailure: async ({ event, error }) => {
+      await db
+        .update(jobs)
+        .set({ status: "failed", error: error.message, finishedAt: new Date() })
+        .where(eq(jobs.id, event.data.event.data.jobId));
+    },
+  },
+  async ({ event, step }) => {
+    const { jobId } = event.data;
+
+    await step.run("mark-running", async () => {
+      await db.update(jobs).set({ status: "running" }).where(eq(jobs.id, jobId));
+    });
+
+    const rows = await step.run("gather-data", async () => {
+      // Throwing here retries. Throwing NonRetriableError gives up immediately.
+      return gatherRowsFor(event.data.userId);
+    });
+
+    const file = await step.run("render-pdf", async () => renderPdf(rows));
+
+    await step.run("finish", async () => {
+      await db
+        .update(jobs)
+        .set({ status: "completed", result: { file }, finishedAt: new Date() })
+        .where(eq(jobs.id, jobId));
+    });
+  },
+);
+
+export const functions = [generateReport];
+```
+
+**How the durability actually works, so the code is written correctly:** each `step.run` result is saved. If the function fails or the server restarts, it runs again from the top — but every step that already finished returns its saved value instead of re-executing. That has two consequences worth stating to the user:
+
+- Code *outside* a step re-runs every time. Anything with a side effect belongs inside a `step.run`.
+- Step ids must be stable and unique within the function. Renaming one mid-flight orphans its saved result.
+
+Throw `NonRetriableError` when retrying cannot help — a missing record, invalid input. Plain errors retry with backoff.
+
+### The jobs table
+
+Postgres branch shown; on SQLite use a `text` id with `$defaultFn(() => crypto.randomUUID())` and `integer` timestamps, per `references/database.md`.
+
+```ts
+export const jobs = pgTable("jobs", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  kind: text("kind").notNull(),
+  userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+  status: text("status").notNull().default("queued"), // queued | running | completed | failed | cancelled
+  eventId: text("event_id"),
+  runId: text("run_id"),
+  input: jsonb("input"),
+  result: jsonb("result"),
+  error: text("error"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  finishedAt: timestamp("finished_at"),
+});
+```
+
+`userId` is `text`, not `uuid`, because it points at a Better Auth table — the trap `references/database.md` warns about. Drop the column entirely if the app has no sign-in.
+
+```bash
+pnpm db:generate
+pnpm db:migrate
+```
+
+### Starting a job
+
+One helper, so the row always exists before the event fires:
+
+```ts
+// src/lib/inngest/enqueue.ts
+import "server-only";
+import { inngest } from "./client";
+import { db } from "@/lib/db";
+import { jobs } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function enqueue(
+  kind: string,
+  eventName: string,
+  input: Record<string, unknown>,
+  userId?: string,
+) {
+  const [job] = await db
+    .insert(jobs)
+    .values({ kind, userId, input, status: "queued" })
+    .returning();
+
+  const { ids } = await inngest.send({
+    name: eventName,
+    data: { ...input, jobId: job.id, userId },
+  });
+
+  await db.update(jobs).set({ eventId: ids[0] }).where(eq(jobs.id, job.id));
+  return job;
+}
+```
+
+Storing the returned event id is what later lets the app ask Inngest what happened to this exact run.
+
+## Watching it work locally
+
+`pnpm dev` starts Next.js and the Inngest dev server together. The dev server's UI is at **http://localhost:8288** — no Docker, no account, no signup.
+
+It shows every event, every run, and every run's steps with timings, inputs, outputs, and retry attempts. Show it to the user: for most people this is the first time background work has been anything other than invisible.
+
+Trigger something from the app and watch it appear. Then make a step throw on purpose and watch it retry — that demonstration is worth more than any explanation of what "durable" means.
+
+## Going to production
+
+1. Sign up at https://app.inngest.com.
+2. **Vercel**: install the Inngest integration from the Vercel marketplace. It sets both keys and re-syncs the app on every deploy, which is the part people otherwise forget.
+3. **Anywhere else** (Railway, Fly, Render, a container): copy the **Event Key** and **Signing Key** from the environment's settings into the host's environment variables as `INNGEST_EVENT_KEY` and `INNGEST_SIGNING_KEY`, deploy, then use **Apps → Sync New App** in the Inngest dashboard with the URL `https://<their-domain>/api/inngest`. Re-sync after any deploy that adds or changes a function.
+
+Do **not** set `INNGEST_DEV` in production — v4 already defaults to cloud mode, and setting it to `0` is unnecessary noise.
+
+Two things that waste an afternoon if unmentioned:
+
+- On a custom domain, set `INNGEST_SERVE_ORIGIN` to it. Otherwise Inngest syncs the `*.vercel.app` deployment URL and calls the wrong host.
+- Vercel's **Deployment Protection** blocks Inngest from reaching the endpoint, so syncs fail with an authentication error that looks like a key problem. Either disable it or configure a protection bypass.
+
+**Free tier:** 50,000 function executions a month, 5 running at once, and 24 hours of history. The execution count is per *step*, not per job — a five-step function burns five. Say this at hand-off so nobody is surprised.
+
+## Controlling jobs from inside the app
+
+`references/ops.md` builds the page. This file provides what it calls. Add `src/lib/inngest/admin.ts`:
+
+```ts
+import "server-only";
+
+const API = "https://api.inngest.com/v2";
+const key = process.env.INNGEST_API_KEY;
+
+async function call(path: string, init?: RequestInit) {
+  if (!key) return null;
+  const res = await fetch(`${API}${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    cache: "no-store",
+  });
+  return res.ok ? res.json() : null;
+}
+
+export const getRun = (runId: string) => call(`/runs/${runId}?includeOutput=true`);
+export const getTrace = (runId: string) => call(`/runs/${runId}/trace`);
+export const cancelRun = (runId: string) => call(`/runs/${runId}/cancel`, { method: "POST" });
+export const rerunRun = (runId: string) => call(`/runs/${runId}/rerun`, { method: "POST" });
+export const runsForEvent = (eventId: string) => call(`/events/${eventId}/runs`);
+```
+
+`INNGEST_API_KEY` is a separate key, created under the account menu → **API Keys** (it starts `sk-inn-api-`), not the event or signing key.
+
+**This module is server-only and must stay that way.** The key is account-wide and not scoped to a user — anything it can read, it can read for every customer. The app's own pages query the `jobs` table (scoped by `userId`), and only reach for these functions to show live detail on a job the current user is already allowed to see.
+
+Cancelling takes effect at the next step boundary, not mid-step. Say that in the UI — "cancelling" is an honest label, "cancelled" the instant the button is clicked is not.
+
+## Verify
+
+- `pnpm dev` starts both processes and the dev server at http://localhost:8288 lists the app and its functions.
+- Triggering the real feature from the app's own UI creates a `jobs` row, then a run appears in the dev server with each step and its timing.
+- A step made to throw retries, is visible retrying, and the `jobs` row ends as `failed` with the error recorded.
+- The `jobs` row reaches `completed` on a successful run, and the app shows that state without the user refreshing something obscure.
+- Job rows are scoped to the user who created them — a second account cannot see the first account's jobs.
+- With `INNGEST_API_KEY` absent, the live detail view degrades to what the `jobs` table knows instead of crashing.
+- With all Inngest env vars absent, the app still starts and the affected feature shows a friendly "background jobs aren't configured yet" notice.

--- a/skills/start-an-app/references/ops.md
+++ b/skills/start-an-app/references/ops.md
@@ -1,0 +1,144 @@
+# System visibility
+
+Last verified: 2026-08-09
+
+**Purpose:** Give the app an inside view of itself — what's configured, what happened, what's running in the background, and what email went out. Every app gets this, scaled to what it actually has.
+
+**This step is not optional.** Everything else in this skill is a branch; this one always runs. An app whose owner cannot see why an email didn't arrive, or that a job has been retrying for an hour, is an app they can only debug by reading logs on a hosting dashboard — which is exactly the moment a new project stops being fun. The panels below appear only if the app has the thing they describe, but the page itself always exists.
+
+> **Hard rule: never render a secret, or part of one.** This page reports whether something is *configured*, never what it is configured with. No API keys, no connection strings, no "sk-...abc4" tails, not even in a tooltip or a copy button. A masked key is still a key with fewer characters to guess, and this page exists to be looked at.
+
+## Who can see it
+
+**If the app has sign-in:** the page lives at `/settings/system`, is linked in the settings nav only for admins, and every page and action behind it calls `requireAdmin()` from `references/settings.md` on the server. Hiding the link is presentation; the guard is the security boundary.
+
+**If the app has no sign-in:** there is nobody to be an admin, so the page renders in development only and does not exist in production.
+
+```tsx
+// src/app/settings/system/page.tsx — no-sign-in apps only
+import { notFound } from "next/navigation";
+
+export default async function SystemPage() {
+  if (process.env.NODE_ENV === "production") notFound();
+  // ...panels
+}
+```
+
+Say why to the user in one line: without accounts there's no way to tell them apart from anyone else on the internet, so a page listing what's wired up doesn't belong on the public site. It's still there while they're building, which is when they need it.
+
+## Health and configuration — always
+
+One card listing every integration the app could have, and whether it's ready. Presence of the environment variable only.
+
+```ts
+// src/lib/system-status.ts
+import "server-only";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+export type Check = { name: string; ready: boolean; hint: string };
+
+export async function getSystemStatus() {
+  const integrations: Check[] = [
+    // Include only the ones this app actually set up.
+    { name: "Email (Resend)", ready: Boolean(process.env.RESEND_API_KEY), hint: "RESEND_API_KEY" },
+    { name: "Background jobs (Inngest)", ready: Boolean(process.env.INNGEST_EVENT_KEY) || process.env.INNGEST_DEV === "1", hint: "INNGEST_EVENT_KEY" },
+    { name: "File uploads", ready: Boolean(process.env.BLOB_READ_WRITE_TOKEN), hint: "BLOB_READ_WRITE_TOKEN — local folder in use until set" },
+    { name: "Payments", ready: Boolean(process.env.POLAR_ACCESS_TOKEN), hint: "POLAR_ACCESS_TOKEN" },
+    { name: "AI", ready: Boolean(process.env.OPENROUTER_API_KEY), hint: "OPENROUTER_API_KEY" },
+  ];
+
+  let database = false;
+  try {
+    await db.execute(sql`select 1`);
+    database = true;
+  } catch {
+    database = false;
+  }
+
+  return { integrations, database };
+}
+```
+
+Render each as a row with a green/grey state and the plain-language hint — the *name* of the variable to set, never its value. "Not configured yet" is a normal state here, not an error: it is exactly what a half-built app looks like, and showing it as a warning trains the user to ignore warnings.
+
+## Activity log — always
+
+The one panel that exists even in the smallest app. A record of things that happened, so the user can answer "when did that change?"
+
+```ts
+export const activityLog = pgTable("activity_log", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: text("user_id").references(() => user.id, { onDelete: "set null" }),
+  action: text("action").notNull(),
+  detail: jsonb("detail"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+```
+
+Postgres branch shown; SQLite uses `text` ids and `integer` timestamps per `references/database.md`. Drop `userId` if there are no accounts.
+
+`onDelete: "set null"` rather than `cascade` — the log outlives the account so "who deleted this?" is still answerable afterwards, with only an anonymous row left behind.
+
+One helper, called from the server actions that already exist:
+
+```ts
+// src/lib/activity.ts
+import "server-only";
+import { db } from "@/lib/db";
+import { activityLog } from "@/lib/db/schema";
+
+export async function logActivity(action: string, detail?: unknown, userId?: string) {
+  await db.insert(activityLog).values({ action, detail, userId });
+}
+```
+
+Log the app's real verbs, in the app's own words — `hike.created`, `invoice.sent`, `member.invited` — not `POST /api/x`. Log writes, not reads. Never put a password, token, or full payload in `detail`; the ids and the changed fields are enough.
+
+Render newest-first with the user's name where there is one, and a date filter. Keep it to the last few hundred rows in the page query — this table grows.
+
+## Background jobs — only if `references/jobs.md` ran
+
+The point of this panel is that background work stops being invisible. It reads the app's own `jobs` table, which is the record, and reaches out to Inngest only for live detail on a single run.
+
+```tsx
+const rows = await db
+  .select()
+  .from(jobs)
+  .orderBy(desc(jobs.createdAt))
+  .limit(50);
+```
+
+Show: what it was, who it was for, status, when it started, how long it took, and the error if it failed. Group or filter by status so a wall of completed jobs doesn't bury the one that broke.
+
+Each row opens a detail view that calls `getRun` and `getTrace` from `src/lib/inngest/admin.ts` to show the step-by-step timeline — which step failed, how many attempts, what each returned. Two buttons:
+
+- **Cancel** → `cancelRun`. Label the result "cancelling", not "cancelled": it takes effect at the next step boundary, not instantly.
+- **Re-run** → `rerunRun`. This starts a *new* run; show the new id rather than pretending the old one restarted.
+
+Both go through a server action that calls `requireAdmin()` first. The Inngest API key is account-wide and never reaches the browser.
+
+If `INNGEST_API_KEY` isn't set, the list still works from the `jobs` table and the detail view says live detail needs the key — degraded, not broken.
+
+Non-admin users should still see *their own* jobs somewhere in the app if the app's work is job-shaped ("your export is being prepared"). That belongs on the relevant feature page, scoped by `userId`, not here.
+
+## Email log — only if `references/email.md` ran
+
+Reads `email_log`, newest first: recipient, subject, template, status, and when. Status comes from the send itself and then from the Resend webhook if it was set up, so `sent` becoming `delivered` or `bounced` is visible here.
+
+This is the panel that answers the most common support question a small app gets — "I never got the email" — with an actual answer: it was never sent because the key is missing, it bounced, or it was delivered and is in their spam folder.
+
+Offer a **Resend** action on a failed row, going through the same `sendEmail` helper so the retry is logged too.
+
+Show the recipient address, since an admin needs it to help. Do not show the message body.
+
+## Verify
+
+- The system page exists and is reachable: linked in settings navigation for an admin account, and not linked for a normal one.
+- Visiting `/settings/system` directly as a non-admin is refused by the server, not just hidden.
+- No-sign-in apps: the page renders with `pnpm dev` and returns 404 after `pnpm build && pnpm start`.
+- The health card lists every integration this app set up, correctly reflects which are configured, and shows no key, token, or connection string anywhere — check the rendered HTML, not just the screen.
+- Doing the app's main action writes an activity row that reads in plain language.
+- Jobs branch: a running job appears with its steps, cancelling it moves it out of running, and re-running it starts a new run.
+- Email branch: an email sent from the app appears in the log with the right status, and a failed send can be retried from the page.
+- With `.env` emptied, the page still renders, shows everything as not configured, and nothing crashes.

--- a/skills/start-an-app/references/pages.md
+++ b/skills/start-an-app/references/pages.md
@@ -82,6 +82,8 @@ export default async function DashboardLayout({
 
 **Check the session on the server, in the layout or page.** Middleware is fine as an optimistic redirect to keep signed-out users from seeing a flash of the dashboard, but it is not the security boundary — a client-side or middleware-only check can be bypassed. Anything that reads or writes user data re-checks the session where it runs.
 
+Leave room in the navigation for **Settings** — `references/settings.md` builds it next and hangs it off whatever nav you write here. It needs a place to live, not a placeholder page.
+
 The dashboard page itself shows **their real data**, scoped to the signed-in user — the nouns from the interview, filtered by `userId`, with the primary action ("Log a hike") in reach. A page that only says "Welcome back, user@example.com" proves auth works and nothing else; go one step further and render the actual thing the app is for.
 
 Scope every query by the session user. On a multi-user app, a query that forgets `where(eq(table.userId, session.user.id))` shows everyone each other's data — check each one.

--- a/skills/start-an-app/references/settings.md
+++ b/skills/start-an-app/references/settings.md
@@ -1,0 +1,324 @@
+# Account settings
+
+Last verified: 2026-08-09
+
+**Purpose:** The place a signed-in person manages themselves — their profile, whether their email is confirmed, their password, the devices they're signed in on, and how to leave. Every app with accounts owes people this, and an app without it feels unfinished the first time someone asks "how do I change my password?"
+
+**Prerequisite: sign-in must exist.** If the app has no accounts, skip this file entirely and go straight to `references/ops.md`, which builds the system page on its own.
+
+> **Hard rule: every panel here is built on Better Auth's own API.** Do not write a route that updates the `user` table directly, hashes a password by hand, or deletes a user row with Drizzle. Better Auth owns anything that belongs to a user — the same rule that governs payments — and going around it means sessions that don't get revoked, tokens that don't get cleaned up, and a password hash format that quietly diverges from the one sign-in checks against.
+>
+> If Better Auth's documentation and this file disagree on *how to structure the page*, this file wins. If they disagree on a method name or option, their docs win — update this file afterwards, because this is the fastest-moving dependency in the stack.
+
+## Two settings that have to change first
+
+Both live in `src/lib/auth.ts`, and both cause bugs that only appear in production if skipped.
+
+```ts
+export const auth = betterAuth({
+  // ...existing config
+
+  session: {
+    freshAge: 0,
+  },
+
+  user: {
+    additionalFields: {
+      role: {
+        type: ["user", "admin"],
+        required: false,
+        defaultValue: "user",
+        input: false,
+      },
+    },
+    changeEmail: { enabled: true },
+    deleteUser: { enabled: true },
+  },
+
+  rateLimit: {
+    enabled: true,
+    storage: "database",
+    customRules: {
+      "/send-verification-email": { window: 60, max: 2 },
+      "/change-email": { window: 60, max: 3 },
+      "/change-password": { window: 60, max: 5 },
+      "/delete-user": { window: 60, max: 3 },
+    },
+  },
+});
+```
+
+**`freshAge: 0`** — by default Better Auth treats a session older than 24 hours as "not fresh" and refuses to list sessions. The devices panel would then work for a day and start returning 403 to every returning user, while the revoke buttons kept working, which reads as a bug in the page rather than a policy. Turning the gate off and requiring a password on the genuinely dangerous action (deletion) is the clearer trade. Say it in a comment so nobody "fixes" it back.
+
+**`input: false` on `role`** is the security control, not a formality. Without it the role is an ordinary profile field and a user can set their own to `admin` through the normal update call.
+
+`rateLimit` is disabled in development and defaults to in-memory storage, which does nothing across serverless instances — `storage: "database"` is what makes the resend cooldown real.
+
+Adding `additionalFields` and `rateLimit` changes the schema, so regenerate and migrate:
+
+```bash
+pnpm dlx @better-auth/cli@latest generate --config src/lib/auth.ts --output src/lib/db/auth-schema.ts -y
+pnpm db:generate
+pnpm db:migrate
+```
+
+## First account becomes the admin
+
+Someone has to be able to see the system page, and asking the user to hand-edit a database row is a bad first experience. The first account created gets `admin`; everyone after gets `user`.
+
+```ts
+import { count } from "drizzle-orm";
+import { user as userTable } from "@/lib/db/auth-schema";
+
+databaseHooks: {
+  user: {
+    create: {
+      before: async (user) => {
+        const [row] = await db.select({ n: count() }).from(userTable);
+        return { data: { ...user, role: row.n === 0 ? "admin" : "user" } };
+      },
+    },
+  },
+},
+```
+
+Then one helper, used by every admin-only page and action:
+
+```ts
+// src/lib/auth-guards.ts
+import "server-only";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+
+export async function requireUser() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) throw new Error("Not signed in");
+  return session;
+}
+
+export async function requireAdmin() {
+  const session = await requireUser();
+  if (session.user.role !== "admin") throw new Error("Not allowed");
+  return session;
+}
+```
+
+Two accounts created in the same instant could both come out as admin. For a new app with one owner that is not worth solving; if the user asks, the answer is a unique partial index or seeding the role deliberately. Mention it only if they ask.
+
+## The shell
+
+`src/app/(dashboard)/settings/layout.tsx` — inside the existing dashboard route group, so it inherits the sign-in check `references/pages.md` already wrote.
+
+```tsx
+import Link from "next/link";
+import { requireUser } from "@/lib/auth-guards";
+
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const session = await requireUser();
+  const isAdmin = session.user.role === "admin";
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-8 md:flex-row">
+      <nav className="flex gap-1 overflow-x-auto md:w-48 md:flex-col">
+        <Link href="/settings">Profile</Link>
+        <Link href="/settings/account">Account</Link>
+        <Link href="/settings/security">Security</Link>
+        {/* Notifications — only if email was set up */}
+        {/* Billing — only if payments were set up */}
+        {isAdmin && <Link href="/settings/system">System</Link>}
+      </nav>
+      <main className="flex-1 space-y-6">{children}</main>
+    </div>
+  );
+}
+```
+
+One route per section, one shadcn `Card` per concern, each card with its own save button. Never one giant form with a single Save — the user has no idea what they're about to change, and one validation error blocks everything.
+
+**Build only the sections this app has.** A personal tool with no payments has no Billing tab; an app that never chose email has no Notifications tab. An empty section is worse than a missing one.
+
+## Profile — `/settings`
+
+Name and avatar. `authClient.updateUser({ name, image })`. If the app took uploads (`references/storage.md`), the avatar goes through the existing upload route rather than a second one.
+
+If the interview turned up profile fields that belong to *their* app — a display handle, a default currency, a home trail — add them as `additionalFields` and put them here. This is the section that stops the settings area feeling generic.
+
+## Account — `/settings/account`
+
+**Email and verification status.** Show the address with a badge, and the resend control only when it's needed:
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { authClient } from "@/lib/auth-client";
+
+export function VerifyEmailCard({ email, verified }: { email: string; verified: boolean }) {
+  const [cooldown, setCooldown] = useState(0);
+
+  useEffect(() => {
+    if (!cooldown) return;
+    const t = setTimeout(() => setCooldown((c) => c - 1), 1000);
+    return () => clearTimeout(t);
+  }, [cooldown]);
+
+  if (verified) return <Badge variant="secondary">Email confirmed</Badge>;
+
+  return (
+    <div>
+      <p>We sent a confirmation link to {email}.</p>
+      <Button
+        disabled={cooldown > 0}
+        onClick={() =>
+          authClient.sendVerificationEmail(
+            { email, callbackURL: "/settings/account" },
+            {
+              onSuccess: () => setCooldown(60),
+              onError: (ctx) => {
+                const retry = Number(ctx.response.headers.get("X-Retry-After"));
+                setCooldown(retry || 60);
+              },
+            },
+          )
+        }
+      >
+        {cooldown > 0 ? `Resend in ${cooldown}s` : "Resend confirmation"}
+      </Button>
+    </div>
+  );
+}
+```
+
+Hide the button entirely once verified — the endpoint returns a 400 for an already-verified user, and surfacing that error where a success message belongs is confusing.
+
+**Changing email** needs a sender. `changeEmail.enabled: true` on its own returns a 400 unless `emailVerification.sendVerificationEmail` is also configured, which only happens if `references/email.md` ran.
+
+- **Email was set up:** `authClient.changeEmail({ newEmail, callbackURL: "/settings/account" })`. A link goes to the *new* address and the change applies when it's clicked. Word the confirmation as "check your new inbox", never "email changed" — Better Auth deliberately returns success even when the address already belongs to somebody else, so that the page can't be used to discover who has an account.
+- **Email was not set up:** render the field disabled with one honest line — "changing your email needs email sending set up first" — rather than a button that 400s.
+
+**Linked sign-in methods** — only if Google sign-in was chosen. `authClient.listAccounts()` to show what's connected, `linkSocial` and `unlinkAccount` for the buttons. Keep `account.accountLinking.allowUnlinkingAll` at its default `false` so nobody can remove their last way in. A row with `providerId: "credential"` means they have a password.
+
+## Security — `/settings/security`
+
+**Change password:**
+
+```ts
+await authClient.changePassword({
+  currentPassword,
+  newPassword,
+  revokeOtherSessions: true,
+});
+```
+
+`currentPassword` is required. `revokeOtherSessions: true` should be checked by default — changing a password usually means "someone might have it".
+
+**Set a password**, for accounts created through Google that have never had one. `auth.api.setPassword` is server-only, so it goes in a server action. It throws if a password already exists — use `listAccounts()` to decide which card to render rather than calling it and catching.
+
+**Active sessions and devices.** `authClient.listSessions()` returns each session with `ipAddress`, `userAgent`, `createdAt` and `token`. Render one row each: a readable device line, the IP, when it was last active, and a **Revoke** button calling `authClient.revokeSession({ token })`. Mark the row whose token matches the current session as **This device** and don't offer to revoke it. Add "Sign out everywhere else" wired to `revokeOtherSessions()`.
+
+Parse the user-agent into something human — "Chrome on Windows" — rather than printing the raw string. A small lookup is fine; a dependency is fine too.
+
+## Notifications — `/settings/notifications`
+
+Only if `references/email.md` ran. Otherwise there is nothing to opt out of and the tab should not exist.
+
+A small table, following the id conventions in `references/database.md`:
+
+```ts
+export const notificationPreference = pgTable("notification_preference", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  category: text("category").notNull(),
+  enabled: boolean("enabled").notNull().default(true),
+});
+```
+
+The categories are the ones this app actually sends — the emails named in the interview, not a generic list.
+
+> **Transactional email ignores these preferences.** Password resets, email confirmation, receipts, and account-security notices always send, and never carry an unsubscribe link. Only optional mail — digests, product updates, activity summaries — checks the table. Putting an unsubscribe link on a password reset is how people lock themselves out.
+
+## Billing — `/settings/billing`
+
+Only if payments were set up. There is nothing to build: show the current plan from the server-side subscription state, then link to the provider's hosted portal that `references/payments.md` already wired (`authClient.customer.portal()` for Polar, the Stripe equivalent otherwise). Do not rebuild cancel, invoice, or card-change screens.
+
+## Danger zone — bottom of `/settings/account`
+
+A separate card, visually distinct, with real whitespace between it and anything harmless above it. Deletion is immediate and permanent — there is no grace period and no undo, so the confirmation has to carry the weight.
+
+Configure it in `src/lib/auth.ts`:
+
+```ts
+user: {
+  deleteUser: {
+    enabled: true,
+    deleteTokenExpiresIn: 60 * 60,
+    sendDeleteAccountVerification: ({ user, url }) => {
+      void sendEmail({
+        to: user.email,
+        subject: "Confirm deleting your account",
+        react: ConfirmDeleteEmail({ url }),
+        template: "confirm-delete",
+      });
+    },
+    beforeDelete: async (user) => {
+      // Payments branch only: cancel the subscription here, BEFORE the row goes.
+      // Doing it after means a failure leaves a live subscription with no account.
+    },
+    afterDelete: async (user) => {
+      // Uploads branch only: delete their files from storage.
+    },
+  },
+},
+```
+
+Without `sendDeleteAccountVerification`, `deleteUser()` deletes immediately on the API call — which is why the email step matters even though deletion itself is immediate.
+
+The dialog, in order:
+
+1. Say exactly what disappears, counted from their real data: "This deletes your account and all 47 hikes. This cannot be undone."
+2. If they're paying, say so: "Your Pro subscription will be cancelled."
+3. Offer **Download my data** first.
+4. Require them to **type their email address** to enable the button. Typing their own address beats typing "DELETE" — it's harder to do by reflex and it restates whose account this is.
+5. Require their password.
+6. `authClient.deleteUser({ password, callbackURL: "/goodbye" })` → they get an email → clicking the link deletes the account, clears every session, and lands on `/goodbye`.
+
+**Download my data** is a small server action, not a job: read the signed-in user's own rows and return JSON.
+
+```ts
+export async function exportMyData() {
+  const session = await requireUser();
+  const data = {
+    exportedAt: new Date().toISOString(),
+    user: { name: session.user.name, email: session.user.email, createdAt: session.user.createdAt },
+    // ...their rows from this app's tables, scoped by userId
+  };
+  return new Response(JSON.stringify(data, null, 2), {
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Disposition": 'attachment; filename="my-data.json"',
+    },
+  });
+}
+```
+
+Include the things they created. Never include password hashes, OAuth tokens, or anything belonging to another user.
+
+## The unverified-email banner
+
+In the dashboard layout, above the content, whenever `session.user.emailVerified` is false:
+
+> **Confirm your email.** We sent a link to you@example.com. [Resend] [Change email]
+
+Do not lock the app. Let people look around, and gate only the things that would embarrass them or the app if done from an unconfirmed address — inviting others, sending outbound email, publishing something public, paying. That list comes from the interview, not from a default.
+
+## Verify
+
+- `/settings` is reachable from the app's navigation, not just by typing the URL.
+- Changing a name saves and the new name shows in the header without a hard refresh.
+- A brand-new account shows the unverified banner; confirming the email clears it and the badge flips.
+- The resend button disables for 60 seconds and disappears entirely once verified.
+- Changing a password works, and with "sign out other devices" checked, a second browser's session is actually ended.
+- The devices list shows the current session marked as this device, and revoking another session signs it out — confirm in a second browser, and confirm the list still loads for an account signed in more than a day ago.
+- Deleting a test account sends the confirmation email, the link removes the account and its data, and signing in with it afterwards fails.
+- A second account cannot see the first account's data anywhere in the settings area, and `/settings/system` is not in its navigation.
+- Every section that exists corresponds to something this app actually has — no empty Billing tab, no Notifications tab without email.
+- With `.env` values absent, the settings pages still render and the affected controls show a friendly "not configured yet" note instead of crashing.


### PR DESCRIPTION
## What this adds

`start-an-app` covered database, sign-in, uploads, payments, AI and pages. Four gaps closed here:

1. **No transactional email.** Step 1b already asked *"Does anyone need telling?"* — nothing sat behind that question, so Better Auth's verification and password reset were never wired up.
2. **No background processing.** Slow, retryable, scheduled or restartable work had nowhere to live.
3. **No account area.** A scaffolded SaaS shipped with no way to view a profile, see verification status, change a password, or delete an account.
4. **No operational visibility.** Nothing the skill built was inspectable at runtime.

## New reference files

| File | Covers |
|---|---|
| `references/email.md` | Resend + React Email 6, domain/DNS walkthrough, `email_log`, Better Auth verification & reset |
| `references/jobs.md` | Inngest v4, local dev server, the app's own `jobs` table, cancel/re-run proxy |
| `references/settings.md` | `/settings` shell, admin role, profile, security, devices, notifications, danger zone |
| `references/ops.md` | `/settings/system` — health, activity log, jobs panel, email log |

`email.md` and `jobs.md` are opt-in branches. `settings.md` and `ops.md` are **unconditional** — every app gets a settings area and a system page, scaled to what that app actually has.

## Design decisions

- **Email stays opt-in.** Sign-in without email keeps working exactly as before. With no API key, messages print to the terminal and are logged to the database, so sign-up and password reset work end to end before the user owns a domain.
- **Inngest only, no Postgres-queue branch.** A long-lived worker is architecturally impossible on Vercel (functions are request-scoped; Hobby cron runs once per *day*), so a pg-boss branch would have been viable only on Railway/Fly/Render. One path that works everywhere beats two that need a deploy-target question.
- **The app owns its own records.** `jobs` and `email_log` rows are written *before* the external call. For Inngest this is load-bearing rather than defensive: the free tier keeps 24 hours of history and its API is account-wide rather than per-user, so it can be neither the archive nor something a user may query.
- **First registered account becomes admin**, via a Better Auth database hook, with `input: false` on the role field so a client can't set its own.
- **Account deletion is immediate** and email-confirmed — no soft-delete, no grace period, no reaper to run.

## Correctness notes

Written against current APIs and verified against **shipped type definitions**, not documentation. Several claims would have been wrong from memory:

- Inngest's TypeScript SDK v4 (GA March 2026) moved `triggers` into the config object, replaced `EventSchemas`, and now defaults to cloud mode — a signing key is required unless `INNGEST_DEV=1`. Nearly every tutorial online is still v3.
- React Email 6 collapsed everything into a single `react-email` package; `@react-email/components` is legacy but still resolves, so the mistake is silent.
- Better Auth 1.4 removed `sendChangeEmailVerification` and renamed `forgotPassword()` to `requestPasswordReset()`.
- `session.freshAge` defaults to 24h and gates `listSessions()` — the devices list 403s for any user signed in longer than a day while revoke keeps working. Production-only and silent.
- `resend.emails.send()` returns `{ data, error }` and does not throw; a bare `try/catch` swallows every rejected send.

Confirmed directly against the packages: `serve()` returns `{GET, POST, PUT}`; `checkpointing.maxRuntime` accepts `"200s"`; Resend's webhook `Headers` is a local `{id, timestamp, signature}` interface rather than the web `Headers` object; `verify()` is synchronous; `idempotencyKey` belongs in the second argument.

## Verification status

- All 11 reference files carry a `Last verified` date and a `## Verify` section.
- Every `references/*.md` named in `SKILL.md` exists; no orphaned files.
- Package names and versions confirmed against the npm registry; API surfaces confirmed against shipped `.d.ts` files.
- **Not done:** a live end-to-end scaffold run. That needs Docker, a Resend account with a verified domain, and an Inngest account. Structure, routing and API surfaces check out; what remains unproven is that the full sequence runs clean start to finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGbjRWZyb7S94foqNnWjrt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded app-building guidance for transactional email, file uploads, payments, AI features, and background jobs.
  * Added recommendations for account settings, system status, activity logs, and operational visibility.
  * Added setup and verification guidance for email delivery, password recovery, background processing, job monitoring, and production deployment.
  * Documented account controls including profile, security, notifications, billing, data export, and account deletion.
  * Added requirements for app-specific settings, administrative controls, and safe degraded behavior when optional services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->